### PR TITLE
fix: rename add-on in order to avoid slash

### DIFF
--- a/EcosystemBuild.java
+++ b/EcosystemBuild.java
@@ -168,7 +168,7 @@ public class EcosystemBuild implements Callable<Integer> {
             versionOverrides = Map.of("24.*", new VersionConfig(), "25.*", new VersionConfig() {{ extraMvnArgs = List.of("-Pv25"); }});
         }},
         new AddonProject() {{
-            name = "Year/Month Calendar Add-on";
+            name = "Year-Month Calendar Add-on";
             repoUrl = "https://github.com/FlowingCode/YearMonthCalendarAddon";
             notifyUsers = List.of("javier-godoy", "mlopezFC", "paodb");
             versionOverrides = Map.of("24.*", new VersionConfig(), "25.*", new VersionConfig() {{ extraMvnArgs = List.of("-Pv25"); }});


### PR DESCRIPTION
See #80 #89 #93 https://github.com/mstahv/vaadin-ecosystem-build/issues/96#issuecomment-4083728516
> Looking at the build artifact for this add-on, the build duration was 0.0s and no build log was produced. This means the failure occurs before Maven even starts — likely at the git clone step or a pre-build script. 

The name of the add-on is indeed "Year/Month Calendar Add-on". I'll rename it as "Year-Month Calendar Add-on" here, so that Ecosystem can do the build.