### PR TITLE
Add major.minor+ version range

### DIFF
--- a/EcosystemBuild.java
+++ b/EcosystemBuild.java
@@ -1911,6 +1911,13 @@ public class EcosystemBuild implements Callable<Integer> {
             return version.startsWith(prefix);
         }
 
+        // Minor version range: same major, minor >= specified (e.g. "25.1+")
+        if (pattern.endsWith("+")) {
+            int[] floor = extractMajorMinor(pattern.substring(0, pattern.length() - 1));
+            int[] v = extractMajorMinor(version);
+            return v[0] == floor[0] && v[1] >= floor[1];
+        }
+
         // Comparison operators (>=, <=, >, <)
         if (pattern.startsWith(">=")) {
             return compareVersions(version, pattern.substring(2)) >= 0;


### PR DESCRIPTION
Close #118

Adds a new pattern syntax to the version-matching logic used for versionOverrides configuration.

A pattern ending with + (e.g. "25.1+") matches any Vaadin version that shares the same major and has a minor component greater than or equal to the one specified — equivalent to npm's ^ caret range. For example, "25.1+" matches 25.1.0, 25.2.0, and 25.2.0-beta1, but not 24.9.0 or 26.0.0.

This is more expressive than the existing "25.*" wildcard (which matches the entire major series from 25.0 onward) when a configuration should apply only from a certain minor release within a major series.