### PR TITLE
Configure Java 25 for Flowing Code add-ons

### DIFF
--- a/EcosystemBuild.java
+++ b/EcosystemBuild.java
@@ -104,7 +104,6 @@ public class EcosystemBuild implements Callable<Integer> {
             name = "Badge List Add-on";
             repoUrl = "https://github.com/FlowingCode/BadgeList";
             notifyUsers = List.of("javier-godoy", "scardanzan", "paodb");
-            javaVersion = "21-tem";
             versionOverrides = Map.of("24.*", new VersionConfig() {{ branch = "1.x"; }}, "25.*", new VersionConfig() {{ branch = "1.x"; profile = "v25"; }}, "25.1+", new VersionConfig());
         }},
         new AddonProject() {{
@@ -117,7 +116,6 @@ public class EcosystemBuild implements Callable<Integer> {
             name = "Chat Assistant Add-on";
             repoUrl = "https://github.com/FlowingCode/ChatAssistant";
             notifyUsers = List.of("javier-godoy", "scardanzan", "paodb");
-            javaVersion = "21-tem";
             versionOverrides = Map.of("24.*", new VersionConfig(), "25.*", new VersionConfig() {{ profile = "v25"; }});
         }},
         new AddonProject() {{
@@ -142,21 +140,18 @@ public class EcosystemBuild implements Callable<Integer> {
             name = "FontAwesomeIronIconset Add-on";
             repoUrl = "https://github.com/FlowingCode/FontAwesomeIronIconset";
             notifyUsers = List.of("javier-godoy", "scardanzan", "paodb");
-            javaVersion = "21-tem";
             versionOverrides = Map.of("24.*", new VersionConfig(), "25.*", new VersionConfig() {{ profile = "v25"; }});
         }},
         new AddonProject() {{
             name = "Google Maps Add-on";
             repoUrl = "https://github.com/FlowingCode/GoogleMapsAddon";
             notifyUsers = List.of("javier-godoy", "scardanzan", "paodb");
-            javaVersion = "21-tem";
             versionOverrides = Map.of("24.*", new VersionConfig() {{ profile = "v24"; }}, "25.*", new VersionConfig() {{ profile = "v25"; }});
         }},
         new AddonProject() {{
             name = "Grid Exporter Add-on";
             repoUrl = "https://github.com/FlowingCode/GridExporterAddon";
             notifyUsers = List.of("javier-godoy", "scardanzan", "paodb");
-            javaVersion = "21-tem";
             versionOverrides = Map.of("24.*", new VersionConfig(), "25.*", new VersionConfig() {{ profile = "v25"; }});
         }},
         new AddonProject() {{
@@ -175,14 +170,12 @@ public class EcosystemBuild implements Callable<Integer> {
             name = "TwinColGrid Add-on";
             repoUrl = "https://github.com/FlowingCode/TwinColGrid";
             notifyUsers = List.of("javier-godoy", "scardanzan", "paodb");
-            javaVersion = "21-tem";
             versionOverrides = Map.of("24.*", new VersionConfig(), "25.*", new VersionConfig() {{ profile = "v25"; }});
         }},
         new AddonProject() {{
             name = "Year-Month Calendar Add-on";
             repoUrl = "https://github.com/FlowingCode/YearMonthCalendarAddon";
             notifyUsers = List.of("javier-godoy", "scardanzan", "paodb");
-            javaVersion = "21-tem";
             versionOverrides = Map.of("24.*", new VersionConfig(), "25.*", new VersionConfig() {{ profile = "v25"; }});
         }}
     );


### PR DESCRIPTION
There were two related issues found by a recent Ecosystem build:
- JDK 25 requires lombok 1.18.40+
- JDK 23 changed the default compiler behavior to disable implicit annotation processing

Those issues have been addressed in the latest snapshots:
- https://github.com/FlowingCode/ChatAssistant/pull/71
- https://github.com/FlowingCode/FontAwesomeIronIconset/pull/129
- https://github.com/FlowingCode/GoogleMapsAddon/pull/184
- https://github.com/FlowingCode/GridExporterAddon/pull/205
- https://github.com/FlowingCode/TwinColGridAddon/pull/212
- https://github.com/FlowingCode/YearMonthCalendarAddon/pull/121

d1ac68d469a386ab8286715fa572892c6d77eaf3 also configured Java 21 for BadgeList, presumably because of https://github.com/mstahv/vaadin-ecosystem-build/issues/81#issuecomment-5094307173, but it doesn't seem to be related to Java 25, so I'm reverting it too and I will address it after the flaky build resurfaces.